### PR TITLE
forcing path to be None so as to show this bug.

### DIFF
--- a/solve.py
+++ b/solve.py
@@ -79,7 +79,7 @@ class Solver:
                 
     def solve(self):
         logging.info('Solving...')
-        path = self._BFS(self.START, self.END)
+        path = None; # self._BFS(self.START, self.END)
         if path is None:
             logging.error('No path found.')
             self._drawX(self.pixels, self.START)


### PR DESCRIPTION
HI; this is a bug report, not really a pull request.

I noticed that if the path is not found, the _drawX function throws an error.   It says 'PixelAccess' object is not iterable.  I don't know of a trivial fix, but I thought I'd ask you first, just in case you do.

Cheers
  Rob

```
thunderrabbit$ ./solve_maze.sh mazes/mazefeb2014.png 
INFO: Loaded image 'mazes/mazefeb2014.png' ((2480, 3508) pixels).
INFO: Solving...
ERROR: No path found.
Traceback (most recent call last):
  File "solve.py", line 169, in <module>
    solver.solve()
  File "solve.py", line 85, in solve
    self._drawX(self.pixels, self.START)
  File "solve.py", line 100, in _drawX
    x,y = pos
TypeError: 'PixelAccess' object is not iterable
```
