### PR TITLE
Make ColorCenter coordinates int

### DIFF
--- a/solve.py
+++ b/solve.py
@@ -118,7 +118,7 @@ class Solver:
                     x_max, y_max = max(x_max, i), max(y_max, j)
         if not found_color:
             return (0,0), False
-        return (mean([x_min, x_max]), mean([y_min, y_max])), True
+        return (int(mean([x_min, x_max])), int(mean([y_min, y_max]))), True
 
     def _findStart(self):
         logging.info("Finding START point...")


### PR DESCRIPTION
A simple one-liner casting the coordinates in the return of _findColorCenter(self, color) to ints. 

This fixes a problem I encountered: If coordinates of the start point are in between two pixels, e.g. X.5, incrementing/decrementing the coordinates by 1 would never land exactly on the end point if its coordinates are X.0, or vice versa. Thus, the program would fail to find a path and raise an error.

This simple fix makes this really cool utility work for my examples and might also address #7.
